### PR TITLE
Update to use standardized asm macro

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -9,7 +9,7 @@ fn main() {
     };
 
     match version_info.channel {
-        Channel::Beta | Channel::Stable => {
+        Channel::Beta | Channel::Stable  if version_info.semver.minor < 59 => {
             panic!("this crate is not supported on the stable, or beta versions");
         }
         _ => {}
@@ -18,8 +18,10 @@ fn main() {
     // determine the kind of asm to use
     if version_info.semver.major > 1 {
         panic!("please update this crate with the breaking rustc 2.0 changes.")
+    } else if version_info.semver.minor >= 59 {
+        // nothing to do.  asm macro stabalized in version 1.59
     } else if version_info.semver.minor >= 46 {
-        // nothing to do
+        println!(r#"cargo:rustc-cfg=feature="LLVM_ASM""#);
     } else {
         println!(r#"cargo:rustc-cfg=feature="OLD_ASM""#);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(not(feature = "OLD_ASM"), feature(llvm_asm))]
+#![cfg_attr(feature = "LLVM_ASM", feature(llvm_asm))]
 #![cfg_attr(feature = "OLD_ASM", feature(asm))]
+
 
 #[inline(never)]
 #[cfg(target_arch = "x86_64")]
@@ -9,7 +10,7 @@ pub fn ticks() -> u64 {
     let high: u64;
     let low: u64;
     unsafe {
-        #[cfg(not(feature = "OLD_ASM"))]
+        #[cfg(feature = "LLVM_ASM")]
         {
             llvm_asm!("lfence;rdtsc"
                 : "={edx}"(high), "={eax}"(low)
@@ -18,7 +19,6 @@ pub fn ticks() -> u64 {
                 : "volatile"
             );
         }
-
         #[cfg(feature = "OLD_ASM")]
         {
             asm!("lfence;rdtsc"
@@ -27,6 +27,12 @@ pub fn ticks() -> u64 {
                 : "rdx", "rax"
                 : "volatile"
             );
+        }
+        #[cfg(all(not(feature = "LLVM_ASM"), not(feature = "OLD_ASM")))]
+        {
+            core::arch::asm!("lfence;rdtsc",
+            out("edx") high,
+            out("eax") low)
         }
     }
     ((high) << 32) | (mask & low)
@@ -52,7 +58,7 @@ pub fn ticks_amd() -> u64 {
     let high: u64;
     let low: u64;
     unsafe {
-        #[cfg(not(feature = "OLD_ASM"))]
+        #[cfg(feature = "LLVM_ASM")]
         {
             llvm_asm!("mfence;rdtsc"
                 : "={edx}"(high), "={eax}"(low)
@@ -69,6 +75,12 @@ pub fn ticks_amd() -> u64 {
                 : "rdx", "rax"
                 : "volatile"
             );
+        }
+        #[cfg(all(not(feature = "LLVM_ASM"), not(feature = "OLD_ASM")))]
+        {
+            core::arch::asm!("mfence;rdtsc",
+            out("edx") high,
+            out("eax") low)
         }
     }
     ((high) << 32) | (mask & low)
@@ -91,7 +103,7 @@ pub fn ticks_modern() -> u64 {
     let high: u64;
     let low: u64;
     unsafe {
-        #[cfg(not(feature = "OLD_ASM"))]
+        #[cfg(feature = "LLVM_ASM")]
         {
             llvm_asm!("rdtscp"
                 : "={edx}"(high), "={eax}"(low)
@@ -109,6 +121,12 @@ pub fn ticks_modern() -> u64 {
                 : "volatile"
             );
         }
+        #[cfg(all(not(feature = "LLVM_ASM"), not(feature = "OLD_ASM")))]
+        {
+            core::arch::asm!("rdtscp",
+            out("edx") high,
+            out("eax") low)
+        }
     }
     ((high) << 32) | (mask & low)
 }
@@ -119,7 +137,7 @@ pub fn ticks() -> u64 {
     let high: u32;
     let low: u32;
     unsafe {
-        #[cfg(not(feature = "OLD_ASM"))]
+        #[cfg(feature = "LLVM_ASM")]
         {
             llvm_asm!("lfence;rdtsc"
                 : "={edx}"(high), "={eax}"(low)
@@ -136,6 +154,12 @@ pub fn ticks() -> u64 {
                 : "rdx", "rax"
                 : "volatile"
             );
+        }
+        #[cfg(all(not(feature = "LLVM_ASM"), not(feature = "OLD_ASM")))]
+        {
+            core::arch::asm!("rdtscp",
+            out("edx") high,
+            out("eax") low)
         }
     }
     let high_val = (high as u64) << 32;
@@ -156,7 +180,7 @@ pub fn ticks_amd() -> u64 {
     let high: u32;
     let low: u32;
     unsafe {
-        #[cfg(not(feature = "OLD_ASM"))]
+        #[cfg(feature = "LLVM_ASM")]
         {
             llvm_asm!("mfence;rdtsc"
                 : "={edx}"(high), "={eax}"(low)
@@ -173,6 +197,12 @@ pub fn ticks_amd() -> u64 {
                 : "edx", "eax"
                 : "volatile"
             );
+        }
+        #[cfg(all(not(feature = "LLVM_ASM"), not(feature = "OLD_ASM")))]
+        {
+            core::arch::asm!("mfence;rdtsc",
+            out("edx") high,
+            out("eax") low)
         }
     }
     let high_val = (high as u64) << 32;
@@ -197,7 +227,7 @@ pub fn ticks_modern() -> u64 {
     let high: u32;
     let low: u32;
     unsafe {
-        #[cfg(not(feature = "OLD_ASM"))]
+        #[cfg(feature = "LLVM_ASM")]
         {
             llvm_asm!("rdtscp"
                 : "={edx}"(high), "={eax}"(low)
@@ -214,6 +244,12 @@ pub fn ticks_modern() -> u64 {
                 : "edx", "eax"
                 : "volatile"
             );
+        }
+        #[cfg(all(not(feature = "LLVM_ASM"), not(feature = "OLD_ASM")))]
+        {
+            core::arch::asm!("rdtscp",
+            out("edx") high,
+            out("eax") low)
         }
     }
     let high_val = (high as u64) << 32;


### PR DESCRIPTION
The `asm!` macro was stabalized in version 1.59.  The `llvm_asm` macro was deprecated and is no longer available in newer releases of Rust.

This adds a new option to use the standardized `asm!` macro.  Since the code is stabilized, if newer versions of Rust are used (>=1.59) nightly version of Rust is no longer needed to use this crate.

This PR is to resolve the issue from #4 